### PR TITLE
Switched over to mio-serial to avoid 100% cpu usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialitm"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["David Haig <david@ninjasource.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,15 @@ categories = ["embedded", "no-std"]
 readme = "README.md"
 
 [dependencies]
-serialport = "3.2"
 clap = "2.33"
 itm = "0.3"
 chrono = "0.4"
+mio-serial = "3.3.1"
+mio = "^0.6.0"
+
+[target.'cfg(unix)'.dependencies]
+nix = "^0.17"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["commapi", "handleapi", "winbase"] }
+mio-named-pipes = "0.1.5"


### PR DESCRIPTION
As title really. I've been using it to monitor ITM while doing embedded dev and it uses 100% cpu all the time. Now it uses 0% cpu according to top.

Could have used tokio instead but I didn't see the point in converting it to async/await when it's really single threaded.

The implementation is copied more or less directly from the mio-serial serial-printline example.

I bumped the version number in case you want to publish it on crates.io

Cheers
Daniel